### PR TITLE
Add manual dispatch Terraform destroy pipeline

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,109 @@
+name: Terraform Destroy
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "destroy" to confirm teardown of all infrastructure'
+        type: string
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  validate-input:
+    name: Validate Confirmation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation input
+        if: inputs.confirm != 'destroy'
+        run: |
+          echo "::error::You must type 'destroy' to confirm. Got: '${{ inputs.confirm }}'"
+          exit 1
+
+  plan-destroy:
+    name: Terraform Plan (Destroy)
+    runs-on: ubuntu-latest
+    needs: validate-input
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ci-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Plan (destroy)
+        run: terraform -chdir=terraform plan -destroy -no-color -input=false 2>&1 | tee /tmp/plan.txt
+
+      - name: Write destroy plan to job summary
+        run: |
+          echo "## Terraform Destroy Plan" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/plan.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  approve-destroy:
+    name: Approve Destruction
+    runs-on: ubuntu-latest
+    needs: plan-destroy
+    steps:
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: ShrithikShahapure
+          minimum-approvals: 1
+          issue-title: "DESTROY all infrastructure — ${{ github.run_id }}"
+          issue-body: |
+            **This will destroy all Terraform-managed infrastructure.**
+
+            Review the destroy plan in the [workflow run summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Approve this issue to proceed, or close to cancel.
+          exclude-workflow-initiator-as-approver: false
+
+  destroy:
+    name: Terraform Destroy
+    runs-on: ubuntu-latest
+    needs: approve-destroy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ci-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Destroy
+        run: terraform -chdir=terraform destroy -auto-approve -input=false
+
+      - name: Write result to job summary
+        if: always()
+        run: |
+          echo "## Destroy Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "Status: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Run by: ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Timestamp: $(date -u)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Four-stage safety flow: confirm input → plan destroy → manual approval via GitHub issue → terraform destroy. Destroy plan is written to job summary for review before approval.