### PR TITLE
Parallelize CD pipeline, fix OIDC bootstrap, and harden destroy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,13 +43,21 @@ jobs:
       working_directory: 'frontend'
       test_command: 'npm test'
 
-  # ── Build & Terraform plan run in parallel after gates pass ──────────────────
+  # ── Build, push & scan images (matrix — API and frontend in parallel) ────────
   build-and-push:
-    name: Build & Push ECR Images
+    name: Build ${{ matrix.image }}
     runs-on: ubuntu-latest
     needs: [security, test-go, test-frontend]
-    outputs:
-      image_tag: ${{ steps.meta.outputs.sha }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - image: api
+            dockerfile: backend/Dockerfile.go
+            context: .
+          - image: frontend
+            dockerfile: frontend/Dockerfile
+            context: frontend/
     steps:
       - uses: actions/checkout@v4
 
@@ -65,6 +73,7 @@ jobs:
         run: |
           SHA="${GITHUB_SHA::8}"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "ecr=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/${{ matrix.image }}" >> "$GITHUB_OUTPUT"
 
       - name: Login to ECR
         run: |
@@ -73,65 +82,50 @@ jobs:
                            --password-stdin \
                            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
 
-      - name: Build & push API image
+      - name: Build & push
         run: |
-          ECR_API="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/api"
+          IMAGE="${{ steps.meta.outputs.ecr }}"
           SHA="${{ steps.meta.outputs.sha }}"
-          docker build -f backend/Dockerfile.go -t "${ECR_API}:${SHA}" -t "${ECR_API}:latest" .
-          docker push "${ECR_API}:${SHA}"
-          docker push "${ECR_API}:latest"
+          docker build -f ${{ matrix.dockerfile }} \
+            -t "${IMAGE}:${SHA}" -t "${IMAGE}:latest" \
+            ${{ matrix.context }}
+          docker push "${IMAGE}:${SHA}"
+          docker push "${IMAGE}:latest"
 
-      - name: Build & push frontend image
-        run: |
-          ECR_FRONTEND="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/frontend"
-          SHA="${{ steps.meta.outputs.sha }}"
-          docker build -f frontend/Dockerfile -t "${ECR_FRONTEND}:${SHA}" -t "${ECR_FRONTEND}:latest" frontend/
-          docker push "${ECR_FRONTEND}:${SHA}"
-          docker push "${ECR_FRONTEND}:latest"
-
-      # ── Trivy image scanning (post-build, pre-deploy) ───────────────────────
-      - name: Trivy scan API image (SARIF)
+      - name: Trivy scan (SARIF)
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/api:${{ steps.meta.outputs.sha }}
+          image-ref: ${{ steps.meta.outputs.ecr }}:${{ steps.meta.outputs.sha }}
           format: sarif
-          output: trivy-api-image.sarif
+          output: trivy-${{ matrix.image }}.sarif
           severity: CRITICAL,HIGH
           ignore-unfixed: true
 
-      - name: Upload API image SARIF
+      - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4
         if: success() || failure()
         with:
-          sarif_file: trivy-api-image.sarif
-          category: trivy-api-image
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-${{ matrix.image }}-image
         continue-on-error: true
 
-      - name: Trivy scan frontend image (SARIF)
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/frontend:${{ steps.meta.outputs.sha }}
-          format: sarif
-          output: trivy-frontend-image.sarif
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-
-      - name: Upload frontend image SARIF
-        uses: github/codeql-action/upload-sarif@v4
-        if: success() || failure()
-        with:
-          sarif_file: trivy-frontend-image.sarif
-          category: trivy-frontend-image
-        continue-on-error: true
-
-      - name: Fail on CRITICAL image vulnerabilities
+      - name: Fail on CRITICAL vulnerabilities
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-          ECR_API="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/api"
-          ECR_FRONTEND="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPO_PREFIX }}/frontend"
-          SHA="${{ steps.meta.outputs.sha }}"
-          trivy image --severity CRITICAL --exit-code 1 --no-progress --ignorefile .trivyignore "${ECR_API}:${SHA}"
-          trivy image --severity CRITICAL --exit-code 1 --no-progress --ignorefile .trivyignore "${ECR_FRONTEND}:${SHA}"
+          trivy image --severity CRITICAL --exit-code 1 --no-progress --ignorefile .trivyignore \
+            "${{ steps.meta.outputs.ecr }}:${{ steps.meta.outputs.sha }}"
+
+  # ── Gate: all matrix builds must pass before downstream jobs ─────────────────
+  images-ready:
+    name: Images Ready
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    outputs:
+      image_tag: ${{ steps.tag.outputs.sha }}
+    steps:
+      - name: Set image tag
+        id: tag
+        run: echo "sha=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
   # ── Terraform plan + cost estimate (parallel with build) ─────────────────────
   terraform-plan:
@@ -326,7 +320,7 @@ jobs:
   approve-terraform:
     name: Approve Terraform & Deploy
     runs-on: ubuntu-latest
-    needs: [terraform-plan, build-and-push]
+    needs: [terraform-plan, images-ready]
     steps:
       - uses: trstringer/manual-approval@v1
         with:
@@ -348,7 +342,7 @@ jobs:
             ---
 
             **Commit:** `${{ github.sha }}`
-            **Image tag:** `${{ needs.build-and-push.outputs.image_tag }}`
+            **Image tag:** `${{ needs.images-ready.outputs.image_tag }}`
 
             Full plan details: [workflow run summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
@@ -359,7 +353,7 @@ jobs:
   terraform-apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
-    needs: [approve-terraform, build-and-push]
+    needs: [approve-terraform, images-ready]
     outputs:
       cluster_name: ${{ steps.tf-outputs.outputs.cluster_name }}
     steps:
@@ -392,9 +386,9 @@ jobs:
   deploy-to-eks:
     name: Deploy to EKS
     runs-on: ubuntu-latest
-    needs: [build-and-push, terraform-apply]
+    needs: [images-ready, terraform-apply]
     env:
-      SHA: ${{ needs.build-and-push.outputs.image_tag }}
+      SHA: ${{ needs.images-ready.outputs.image_tag }}
       CLUSTER_NAME: ${{ needs.terraform-apply.outputs.cluster_name }}
     steps:
       - uses: actions/checkout@v4

--- a/scripts/bootstrap-aws.sh
+++ b/scripts/bootstrap-aws.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# bootstrap-aws.sh — Idempotent setup of AWS resources that must exist BEFORE
+# Terraform or GitHub Actions pipelines can run:
+#   1. S3 bucket   (Terraform state)
+#   2. DynamoDB table (Terraform state lock)
+#   3. GitHub OIDC provider
+#   4. github-actions-ci-role (OIDC trust + broad infra permissions)
+#
+# Prerequisites:
+#   - AWS CLI v2 configured with credentials that have IAM + S3 + DynamoDB admin
+#   - jq installed
+#
+# Usage:
+#   ./scripts/bootstrap-aws.sh                 # uses defaults
+#   AWS_REGION=us-west-2 ./scripts/bootstrap-aws.sh  # override region
+
+set -euo pipefail
+
+# ── Configuration (override via env) ──────────────────────────────────────────
+REGION="${AWS_REGION:-us-east-1}"
+STATE_BUCKET="${TF_STATE_BUCKET:-stock-agent-ops-tfstate}"
+LOCK_TABLE="${TF_LOCK_TABLE:-stock-agent-ops-tflock}"
+ROLE_NAME="${CI_ROLE_NAME:-github-actions-ci-role}"
+GITHUB_ORG="${GITHUB_ORG:-ShrithikShahapure}"
+GITHUB_REPO="${GITHUB_REPO:-stock-agent-ops}"
+OIDC_URL="https://token.actions.githubusercontent.com"
+OIDC_AUDIENCE="sts.amazonaws.com"
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "AWS Account: ${ACCOUNT_ID}"
+echo "Region:      ${REGION}"
+echo ""
+
+# ── 1. S3 state bucket ───────────────────────────────────────────────────────
+echo "==> S3 state bucket: ${STATE_BUCKET}"
+if aws s3api head-bucket --bucket "${STATE_BUCKET}" 2>/dev/null; then
+  echo "    Already exists."
+else
+  echo "    Creating..."
+  if [ "${REGION}" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "${STATE_BUCKET}" --region "${REGION}"
+  else
+    aws s3api create-bucket --bucket "${STATE_BUCKET}" --region "${REGION}" \
+      --create-bucket-configuration LocationConstraint="${REGION}"
+  fi
+  aws s3api put-bucket-versioning --bucket "${STATE_BUCKET}" \
+    --versioning-configuration Status=Enabled
+  aws s3api put-bucket-encryption --bucket "${STATE_BUCKET}" \
+    --server-side-encryption-configuration '{
+      "Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]
+    }'
+  aws s3api put-public-access-block --bucket "${STATE_BUCKET}" \
+    --public-access-block-configuration \
+      BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+  echo "    Created."
+fi
+
+# ── 2. DynamoDB lock table ────────────────────────────────────────────────────
+echo "==> DynamoDB lock table: ${LOCK_TABLE}"
+if aws dynamodb describe-table --table-name "${LOCK_TABLE}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "    Already exists."
+else
+  echo "    Creating..."
+  aws dynamodb create-table \
+    --table-name "${LOCK_TABLE}" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --region "${REGION}"
+  aws dynamodb wait table-exists --table-name "${LOCK_TABLE}" --region "${REGION}"
+  echo "    Created."
+fi
+
+# ── 3. GitHub OIDC provider ──────────────────────────────────────────────────
+echo "==> GitHub OIDC provider"
+OIDC_ARN=$(aws iam list-open-id-connect-providers --query \
+  "OpenIDConnectProviderList[?ends_with(Arn, '/token.actions.githubusercontent.com')].Arn | [0]" \
+  --output text 2>/dev/null || true)
+
+if [ -n "${OIDC_ARN}" ] && [ "${OIDC_ARN}" != "None" ]; then
+  echo "    Already exists: ${OIDC_ARN}"
+else
+  echo "    Creating..."
+  # Fetch the current TLS thumbprint
+  THUMBPRINT=$(openssl s_client -servername token.actions.githubusercontent.com \
+    -connect token.actions.githubusercontent.com:443 </dev/null 2>/dev/null \
+    | openssl x509 -fingerprint -noout -sha1 2>/dev/null \
+    | sed 's/sha1 Fingerprint=//;s/://g' \
+    | tr '[:upper:]' '[:lower:]')
+
+  # Fallback to well-known thumbprint if openssl fails
+  if [ -z "${THUMBPRINT}" ]; then
+    THUMBPRINT="6938fd4d98bab03faadb97b34396831e3780aea1"
+  fi
+
+  OIDC_ARN=$(aws iam create-open-id-connect-provider \
+    --url "${OIDC_URL}" \
+    --client-id-list "${OIDC_AUDIENCE}" \
+    --thumbprint-list "${THUMBPRINT}" \
+    --tags Key=Name,Value=github-actions-oidc Key=ManagedBy,Value=bootstrap \
+    --query OpenIDConnectProviderArn --output text)
+  echo "    Created: ${OIDC_ARN}"
+fi
+
+# ── 4. CI role ────────────────────────────────────────────────────────────────
+echo "==> CI role: ${ROLE_NAME}"
+if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
+  echo "    Already exists. Updating trust policy..."
+else
+  echo "    Creating..."
+fi
+
+# Trust policy — allow GitHub Actions OIDC for this org/repo on any branch/event
+TRUST_POLICY=$(cat <<TRUST
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": { "Federated": "${OIDC_ARN}" },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "${OIDC_AUDIENCE}"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:${GITHUB_ORG}/${GITHUB_REPO}:*"
+        }
+      }
+    }
+  ]
+}
+TRUST
+)
+
+if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
+  aws iam update-assume-role-policy --role-name "${ROLE_NAME}" \
+    --policy-document "${TRUST_POLICY}"
+else
+  aws iam create-role --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document "${TRUST_POLICY}" \
+    --description "Assumed by GitHub Actions via OIDC for CI/CD operations" \
+    --tags Key=ManagedBy,Value=bootstrap
+fi
+
+# Inline policy — matches the Terraform IAM module policy
+POLICY=$(cat <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECRLogin",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ECRPushPull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability", "ecr:CompleteLayerUpload",
+        "ecr:GetDownloadUrlForLayer", "ecr:InitiateLayerUpload",
+        "ecr:PutImage", "ecr:UploadLayerPart", "ecr:BatchGetImage",
+        "ecr:DescribeImages", "ecr:DescribeRepositories", "ecr:ListImages"
+      ],
+      "Resource": [
+        "arn:aws:ecr:${REGION}:${ACCOUNT_ID}:repository/stock-agent-ops/*"
+      ]
+    },
+    {
+      "Sid": "TFStateS3",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::${STATE_BUCKET}",
+        "arn:aws:s3:::${STATE_BUCKET}/*"
+      ]
+    },
+    {
+      "Sid": "TFStateLock",
+      "Effect": "Allow",
+      "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"],
+      "Resource": "arn:aws:dynamodb:${REGION}:${ACCOUNT_ID}:table/${LOCK_TABLE}"
+    },
+    {
+      "Sid": "TFStateKMS",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:DescribeKey"],
+      "Resource": "*"
+    },
+    { "Sid": "TFManageVPC",  "Effect": "Allow", "Action": "ec2:*",  "Resource": "*" },
+    { "Sid": "TFManageEKS",  "Effect": "Allow", "Action": "eks:*",  "Resource": "*" },
+    { "Sid": "TFManageIAM",  "Effect": "Allow", "Action": "iam:*",  "Resource": "*" },
+    { "Sid": "TFManageECR",  "Effect": "Allow", "Action": "ecr:*",  "Resource": "*" },
+    { "Sid": "TFManageLogs", "Effect": "Allow", "Action": "logs:*", "Resource": "*" },
+    { "Sid": "TFManageSTS",  "Effect": "Allow", "Action": "sts:GetCallerIdentity", "Resource": "*" }
+  ]
+}
+POLICY
+)
+
+aws iam put-role-policy --role-name "${ROLE_NAME}" \
+  --policy-name "github-actions-ci-policy" \
+  --policy-document "${POLICY}"
+echo "    Policy applied."
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Bootstrap complete."
+echo "  S3 bucket:     ${STATE_BUCKET}"
+echo "  DynamoDB table: ${LOCK_TABLE}"
+echo "  OIDC provider: ${OIDC_ARN}"
+echo "  CI role ARN:   arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+echo ""
+echo "Next steps:"
+echo "  1. Set GitHub secret AWS_ACCOUNT_ID = ${ACCOUNT_ID}"
+echo "  2. Run: terraform -chdir=terraform init"
+echo "  3. Run: terraform -chdir=terraform import aws_iam_openid_connect_provider.github ${OIDC_ARN}"
+echo "  4. Run: terraform -chdir=terraform import aws_iam_role.github_actions_ci ${ROLE_NAME}"
+echo "     (or let Terraform adopt them on next apply)"

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -25,6 +25,8 @@ resource "aws_iam_openid_connect_provider" "github" {
   thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
 
   tags = { Name = "github-actions-oidc" }
+
+  lifecycle { prevent_destroy = true }
 }
 
 # ── Terraform Cloud OIDC provider ────────────────────────────────────────────
@@ -71,6 +73,8 @@ resource "aws_iam_role" "github_actions_ci" {
   name               = "github-actions-ci-role"
   assume_role_policy = data.aws_iam_policy_document.github_assume.json
   description        = "Assumed by GitHub Actions via OIDC for ECR and EKS operations"
+
+  lifecycle { prevent_destroy = true }
 }
 
 data "aws_iam_policy_document" "github_actions_ci" {


### PR DESCRIPTION
## Summary

- **Parallelize CD pipeline**: security, test-go, and test-frontend run concurrently (no serial dependency). Build+push and terraform-plan run in parallel after gates pass. API and frontend images build/scan on separate runners via matrix strategy.
- **Plan + cost in approval issue**: Single trstringer approval gate now includes the terraform plan summary and cost estimate directly in the GitHub issue body (removed redundant second approval gate).
- **OIDC bootstrap script**: Added `scripts/bootstrap-aws.sh` to create the OIDC provider, CI role, S3 state bucket, and DynamoDB lock table via AWS CLI — fixes chicken-and-egg problem where `terraform destroy` deletes the resources pipelines need to authenticate.
- **prevent_destroy on CI resources**: Added `lifecycle { prevent_destroy = true }` to the OIDC provider and CI role in the IAM Terraform module.
- **Targeted destroy pipeline**: Reusable `terraform-destroy.yml` now skips `module.iam` by default so OIDC/CI role survive infrastructure teardowns. Destroy plan and affected resources are shown in the trstringer approval issue.

## Test plan

- [ ] Verify CI pipeline passes (security, tests, terraform validate)
- [ ] Verify CD pipeline jobs run in the correct parallel order
- [ ] Verify trstringer approval issue contains plan summary and cost table
- [ ] Verify `terraform plan` uses S3 backend
- [ ] Run destroy pipeline and confirm IAM module is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)