### PR TITLE
Fix OIDC bootstrap, stale imports, matrix builds, and hardened destroy

### DIFF
--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,15 +1,10 @@
-# Import blocks — tells Terraform to adopt the resources bootstrapped manually
-# via AWS CLI rather than creating them from scratch.
-# These can be removed after the first successful `terraform apply`.
+# Import blocks — adopt the OIDC provider and CI role created by the
+# bootstrap script (scripts/bootstrap-aws.sh).
+# Remove these after the first successful `terraform apply`.
 
 import {
   id = "arn:aws:iam::075223871157:oidc-provider/token.actions.githubusercontent.com"
   to = module.iam.aws_iam_openid_connect_provider.github
-}
-
-import {
-  id = "arn:aws:iam::075223871157:oidc-provider/app.terraform.io"
-  to = module.iam.aws_iam_openid_connect_provider.tfc
 }
 
 import {
@@ -20,59 +15,4 @@ import {
 import {
   id = "github-actions-ci-role:github-actions-ci-policy"
   to = module.iam.aws_iam_role_policy.github_actions_ci
-}
-
-import {
-  id = "terraform-cloud-role"
-  to = module.iam.aws_iam_role.terraform_cloud
-}
-
-import {
-  id = "terraform-cloud-role/arn:aws:iam::aws:policy/AdministratorAccess"
-  to = module.iam.aws_iam_role_policy_attachment.terraform_cloud_admin
-}
-
-import {
-  id = "stock-agent-ops-cluster-role"
-  to = module.iam.aws_iam_role.eks_cluster
-}
-
-import {
-  id = "stock-agent-ops-cluster-role/arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  to = module.iam.aws_iam_role_policy_attachment.eks_cluster_policy
-}
-
-import {
-  id = "stock-agent-ops-node-role"
-  to = module.iam.aws_iam_role.eks_node
-}
-
-import {
-  id = "stock-agent-ops-node-role/arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  to = module.iam.aws_iam_role_policy_attachment.eks_worker_node
-}
-
-import {
-  id = "stock-agent-ops-node-role/arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  to = module.iam.aws_iam_role_policy_attachment.eks_cni
-}
-
-import {
-  id = "stock-agent-ops-node-role/arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  to = module.iam.aws_iam_role_policy_attachment.eks_ecr_readonly
-}
-
-import {
-  id = "stock-agent-ops-node-role/arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
-  to = module.iam.aws_iam_role_policy_attachment.eks_ebs_csi
-}
-
-import {
-  id = "stock-agent-ops/api"
-  to = module.ecr.aws_ecr_repository.api
-}
-
-import {
-  id = "stock-agent-ops/frontend"
-  to = module.ecr.aws_ecr_repository.frontend
 }


### PR DESCRIPTION
## Summary

- **Remove stale import blocks**: `imports.tf` had import blocks for ~15 resources that no longer exist (destroyed previously). Kept only the 3 that were bootstrapped via CLI (OIDC provider, CI role, CI policy). These can be removed after first successful apply.
- **OIDC bootstrap script**: Added `scripts/bootstrap-aws.sh` to create OIDC provider, CI role, S3 state bucket, and DynamoDB lock table via AWS CLI — fixes chicken-and-egg problem.
- **prevent_destroy on CI resources**: `lifecycle { prevent_destroy = true }` on OIDC provider and CI role in the IAM module.
- **Matrix image builds**: API and frontend images build, push, and scan on separate parallel runners.
- **Parallelized CD pipeline**: security/test-go/test-frontend run concurrently, build+push and terraform-plan run in parallel after gates.
- **Plan + cost in approval issue**: Single trstringer gate includes terraform plan summary and cost estimate in the issue body.

## Test plan

- [ ] Verify terraform plan succeeds (imports only the 3 bootstrapped resources)
- [ ] Verify terraform apply creates all infrastructure from scratch
- [ ] Verify matrix build jobs run API and frontend in parallel
- [ ] Verify trstringer approval issue shows plan + cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)